### PR TITLE
fix compile error in ngx_stream_limit_upstream_module.c and core dump…

### DIFF
--- a/nginx-1.14.2-stream.patch
+++ b/nginx-1.14.2-stream.patch
@@ -1,0 +1,107 @@
+--- a/src/stream/ngx_stream_upstream.h	2018-04-13 19:05:12.456091028 +0800
++++ b/src/stream/ngx_stream_upstream.h	2018-04-13 20:07:45.604186242 +0800
+@@ -137,6 +137,7 @@
+     ngx_stream_upstream_state_t       *state;
+     unsigned                           connected:1;
+     unsigned                           proxy_protocol:1;
++    unsigned                           blocked:1;
+ } ngx_stream_upstream_t;
+ 
+ 
+--- a/src/stream/ngx_stream_proxy_module.c	2018-04-12 10:19:21.721098716 +0800
++++ b/src/stream/ngx_stream_proxy_module.c	2018-04-17 14:58:23.554108490 +0800
+@@ -61,7 +61,7 @@
+     ngx_stream_proxy_srv_conf_t *pscf);
+ static ngx_int_t ngx_stream_proxy_set_local(ngx_stream_session_t *s,
+     ngx_stream_upstream_t *u, ngx_stream_upstream_local_t *local);
+-static void ngx_stream_proxy_connect(ngx_stream_session_t *s);
++void ngx_stream_proxy_connect(ngx_stream_session_t *s);
+ static void ngx_stream_proxy_init_upstream(ngx_stream_session_t *s);
+ static void ngx_stream_proxy_resolve_handler(ngx_resolver_ctx_t *ctx);
+ static void ngx_stream_proxy_upstream_handler(ngx_event_t *ev);
+@@ -73,7 +73,7 @@
+ static void ngx_stream_proxy_process(ngx_stream_session_t *s,
+     ngx_uint_t from_upstream, ngx_uint_t do_write);
+ static void ngx_stream_proxy_next_upstream(ngx_stream_session_t *s);
+-static void ngx_stream_proxy_finalize(ngx_stream_session_t *s, ngx_uint_t rc);
++void ngx_stream_proxy_finalize(ngx_stream_session_t *s, ngx_uint_t rc);
+ static u_char *ngx_stream_proxy_log_error(ngx_log_t *log, u_char *buf,
+     size_t len);
+ 
+@@ -646,7 +646,7 @@
+ }
+ 
+ 
+-static void
++void
+ ngx_stream_proxy_connect(ngx_stream_session_t *s)
+ {
+     ngx_int_t                     rc;
+@@ -662,29 +662,35 @@
+ 
+     u = s->upstream;
+ 
+-    u->connected = 0;
+-    u->proxy_protocol = pscf->proxy_protocol;
++    if (!u->blocked) {
++        u->connected = 0;
++        u->proxy_protocol = pscf->proxy_protocol;
+ 
+-    if (u->state) {
+-        u->state->response_time = ngx_current_msec - u->state->response_time;
+-    }
++        if (u->state) {
++            u->state->response_time = ngx_current_msec - u->state->response_time;
++        }
+ 
+-    u->state = ngx_array_push(s->upstream_states);
+-    if (u->state == NULL) {
+-        ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+-        return;
+-    }
++        u->state = ngx_array_push(s->upstream_states);
++        if (u->state == NULL) {
++            ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
++            return;
++        }
+ 
+-    ngx_memzero(u->state, sizeof(ngx_stream_upstream_state_t));
++        ngx_memzero(u->state, sizeof(ngx_stream_upstream_state_t));
+ 
+-    u->state->connect_time = (ngx_msec_t) -1;
+-    u->state->first_byte_time = (ngx_msec_t) -1;
+-    u->state->response_time = ngx_current_msec;
++        u->state->connect_time = (ngx_msec_t) -1;
++        u->state->first_byte_time = (ngx_msec_t) -1;
++        u->state->response_time = ngx_current_msec;
++    }
+ 
+     rc = ngx_event_connect_peer(&u->peer);
+ 
+     ngx_log_debug1(NGX_LOG_DEBUG_STREAM, c->log, 0, "proxy connect: %i", rc);
+ 
++    if (rc == NGX_BLOCK) {
++        return;
++    }
++
+     if (rc == NGX_ERROR) {
+         ngx_stream_proxy_finalize(s, NGX_STREAM_INTERNAL_SERVER_ERROR);
+         return;
+@@ -1663,7 +1669,7 @@
+ }
+ 
+ 
+-static void
++void
+ ngx_stream_proxy_next_upstream(ngx_stream_session_t *s)
+ {
+     ngx_msec_t                    timeout;
+@@ -1729,7 +1735,7 @@
+ }
+ 
+ 
+-static void
++void
+ ngx_stream_proxy_finalize(ngx_stream_session_t *s, ngx_uint_t rc)
+ {
+     ngx_connection_t       *pc;

--- a/nginx-1.14.2.patch
+++ b/nginx-1.14.2.patch
@@ -1,0 +1,104 @@
+diff --git a/src/core/ngx_core.h b/src/core/ngx_core.h
+index 2069373b..e24e5df5 100644
+--- a/src/core/ngx_core.h
++++ b/src/core/ngx_core.h
+@@ -39,6 +39,7 @@ typedef void (*ngx_connection_handler_pt)(ngx_connection_t *c);
+ #define  NGX_DONE       -4
+ #define  NGX_DECLINED   -5
+ #define  NGX_ABORT      -6
++#define  NGX_BLOCK      -7
+ 
+ 
+ #include <ngx_errno.h>
+diff --git a/src/http/ngx_http_upstream.c b/src/http/ngx_http_upstream.c
+index 36952860..a2fa6b34 100644
+--- a/src/http/ngx_http_upstream.c
++++ b/src/http/ngx_http_upstream.c
+@@ -35,8 +35,6 @@ static void ngx_http_upstream_rd_check_broken_connection(ngx_http_request_t *r);
+ static void ngx_http_upstream_wr_check_broken_connection(ngx_http_request_t *r);
+ static void ngx_http_upstream_check_broken_connection(ngx_http_request_t *r,
+     ngx_event_t *ev);
+-static void ngx_http_upstream_connect(ngx_http_request_t *r,
+-    ngx_http_upstream_t *u);
+ static ngx_int_t ngx_http_upstream_reinit(ngx_http_request_t *r,
+     ngx_http_upstream_t *u);
+ static void ngx_http_upstream_send_request(ngx_http_request_t *r,
+@@ -1457,36 +1455,42 @@ ngx_http_upstream_check_broken_connection(ngx_http_request_t *r,
+ }
+ 
+ 
+-static void
++void
+ ngx_http_upstream_connect(ngx_http_request_t *r, ngx_http_upstream_t *u)
+ {
+     ngx_int_t          rc;
+     ngx_connection_t  *c;
+ 
+-    r->connection->log->action = "connecting to upstream";
++    if (!u->blocked) {
++        r->connection->log->action = "connecting to upstream";
+ 
+-    if (u->state && u->state->response_time) {
+-        u->state->response_time = ngx_current_msec - u->state->response_time;
+-    }
++        if (u->state && u->state->response_time) {
++            u->state->response_time = ngx_current_msec - u->state->response_time;
++        }
+ 
+-    u->state = ngx_array_push(r->upstream_states);
+-    if (u->state == NULL) {
+-        ngx_http_upstream_finalize_request(r, u,
+-                                           NGX_HTTP_INTERNAL_SERVER_ERROR);
+-        return;
+-    }
++        u->state = ngx_array_push(r->upstream_states);
++        if (u->state == NULL) {
++            ngx_http_upstream_finalize_request(r, u,
++                                               NGX_HTTP_INTERNAL_SERVER_ERROR);
++            return;
++        }
+ 
+-    ngx_memzero(u->state, sizeof(ngx_http_upstream_state_t));
++        ngx_memzero(u->state, sizeof(ngx_http_upstream_state_t));
+ 
+-    u->state->response_time = ngx_current_msec;
+-    u->state->connect_time = (ngx_msec_t) -1;
+-    u->state->header_time = (ngx_msec_t) -1;
++        u->state->response_time = ngx_current_msec;
++        u->state->connect_time = (ngx_msec_t) -1;
++        u->state->header_time = (ngx_msec_t) -1;
++    }
+ 
+     rc = ngx_event_connect_peer(&u->peer);
+ 
+     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                    "http upstream connect: %i", rc);
+ 
++    if (rc == NGX_BLOCK) {
++        return;
++    }
++
+     if (rc == NGX_ERROR) {
+         ngx_http_upstream_finalize_request(r, u,
+                                            NGX_HTTP_INTERNAL_SERVER_ERROR);
+diff --git a/src/http/ngx_http_upstream.h b/src/http/ngx_http_upstream.h
+index c552ac0c..92bb6229 100644
+--- a/src/http/ngx_http_upstream.h
++++ b/src/http/ngx_http_upstream.h
+@@ -389,6 +389,7 @@ struct ngx_http_upstream_s {
+     unsigned                         request_sent:1;
+     unsigned                         request_body_sent:1;
+     unsigned                         header_sent:1;
++    unsigned                         blocked:1;
+ };
+ 
+ 
+@@ -416,6 +417,8 @@ char *ngx_http_upstream_param_set_slot(ngx_conf_t *cf, ngx_command_t *cmd,
+ ngx_int_t ngx_http_upstream_hide_headers_hash(ngx_conf_t *cf,
+     ngx_http_upstream_conf_t *conf, ngx_http_upstream_conf_t *prev,
+     ngx_str_t *default_hide_headers, ngx_hash_init_t *hash);
++void ngx_http_upstream_connect(ngx_http_request_t *r,
++    ngx_http_upstream_t *u);
+ 
+ 
+ #define ngx_http_conf_upstream_srv_conf(uscf, module)                         \

--- a/ngx_http_limit_upstream_module.c
+++ b/ngx_http_limit_upstream_module.c
@@ -327,7 +327,7 @@ ngx_http_limit_upstream_cleanup(void *data)
         ctx->r->read_event_handler = wnode->read_event_handler;
         ctx->r->write_event_handler = wnode->write_event_handler;
 
-        ngx_del_timer(ctx->r->connection->read);
+        //ngx_del_timer(ctx->r->connection->read);
 
         if (wnode->r_timer_set) {
             if (ctx->r->connection->read->timedout) {

--- a/ngx_stream_limit_upstream_module.c
+++ b/ngx_stream_limit_upstream_module.c
@@ -175,10 +175,7 @@ static ngx_stream_module_t ngx_stream_limit_ups_module_ctx = {
     NULL,
 
     ngx_stream_limit_ups_create_srv_conf,
-    ngx_stream_limit_ups_merge_srv_conf,
-
-    NULL,
-    NULL
+    ngx_stream_limit_ups_merge_srv_conf
 };
 
 


### PR DESCRIPTION
fix compile error in ngx_stream_limit_upstream_module.c and core dump caused by ngx_del_timer.
add patch of version 1.14.2